### PR TITLE
add h5py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-numpy
-scipy
-netcdf4
-joblib
-numpy_groupies
 basemap
+h5py
+joblib
+netcdf4
+numpy
+numpy_groupies
+scipy


### PR DESCRIPTION
While putting https://github.com/conda-forge-linter together I notice that the `h5py` dependency is missing from the requirements.